### PR TITLE
[main] Update bastion module with VNET peering dependency

### DIFF
--- a/modules/Spoke/main.tf
+++ b/modules/Spoke/main.tf
@@ -320,7 +320,9 @@ module "bastion" {
     module.private-endpoint-subnet,
     module.firewall-allow-application-rule,
     module.firewall-allow-dnat-rule,
-    module.firewall-allow-network-rule
+    module.firewall-allow-network-rule,
+    module.hub-to-spoke-vnet-peering,
+    module.spoke-to-hub-vnet-peering
   ]
 }
 


### PR DESCRIPTION
## Description
> The VNET peering to the HUB should be available before creating the Bastion VM to allow the internet traffic via Firewall.